### PR TITLE
Degree migration updates

### DIFF
--- a/includes/class-cba-migrate.php
+++ b/includes/class-cba-migrate.php
@@ -194,7 +194,15 @@ if ( ! class_exists( 'CBA_Migrate_Command' ) ) {
 			$progress = \WP_CLI\Utils\make_progress_bar( 'Migrating degree types...', $count );
 
 			foreach( $this->degree_types as $degree_type_id => $degree_type ) {
-				// Perform a direct 1-to-1 migration to the 'program_types' taxonomy
+				// Perform a direct 1-to-1 migration to the 'program_types'
+				// taxonomy, but rename 'graduate programs' and
+				// 'undergraduate programs'
+				if ( $degree_type === 'Graduate Programs' ) {
+					$degree_type = 'Graduate Program';
+				}
+				else if ( $degree_type === 'Undergraduate Programs' ) {
+					$degree_type = 'Undergraduate Program';
+				}
 				$program_type = wp_insert_term( $degree_type, 'program_types' );
 
 				if ( !is_wp_error( $program_type ) ) {

--- a/includes/class-cba-migrate.php
+++ b/includes/class-cba-migrate.php
@@ -179,6 +179,13 @@ if ( ! class_exists( 'CBA_Migrate_Command' ) ) {
 					}
 				}
 
+				// Set 'degree_import_ignore' flag for the UCF Degree CPT
+				// plugin's degree importer on all executive programs, since
+				// they aren't true degrees but need to be left intact
+				if ( has_term( 'Executive Education', 'degree_types', $degree ) ) {
+					update_post_meta( $degree->ID, 'degree_import_ignore', 'on' );
+				}
+
 				$migrate_count++;
 
 				$progress->tick();


### PR DESCRIPTION
- Degree migration now sets the 'degree_import_ignore' meta field to 'on' for all executive education degrees, allowing them to remain intact after running a degree data import
- Renamed undergraduate and graduate program terms to match what the new degree data importer will expect